### PR TITLE
Easier for annotations, refactor `msp` part, more readable format.

### DIFF
--- a/hyperledger/scripts/invoke_chaincode_template.sh
+++ b/hyperledger/scripts/invoke_chaincode_template.sh
@@ -2,11 +2,11 @@
 set -x
 export CORE_PEER_ADDRESS=org1-peer1:7051
 peer chaincode \
-      invoke \
-      -o org0-orderer1:6050 \
-      --tls --cafile /var/hyperledger/fabric/organizations/ordererOrganizations/org0.example.com/msp/tlscacerts/org0-tls-ca.pem \
-      -n ${CHAINCODE_NAME} \
-      -C ${CHANNEL_NAME} \
-      -c '${parameters}'
+        invoke \
+        -o org0-orderer1:6050 \
+        --tls --cafile /var/hyperledger/fabric/organizations/ordererOrganizations/org0.example.com/msp/tlscacerts/org0-tls-ca.pem \
+        -n ${CHAINCODE_NAME} \
+        -C ${CHANNEL_NAME} \
+        -c '${parameters}'
 
 sleep 2


### PR DESCRIPTION
Thank you Dr. Marchini! Made `\` parallel, again for easier annotation and more readable. 