### PR TITLE
Fix metadata JSON struct tags

### DIFF
--- a/chaincode/artifact-metadata/docker/artifact-metadata.go
+++ b/chaincode/artifact-metadata/docker/artifact-metadata.go
@@ -4,15 +4,17 @@ import (
 	"time"
 )
 
-// Metadata describes basic details of what makes up a simple metadata
-// Insert struct field in alphabetic order => to achieve determinism across languages
-// golang keeps the order when marshal to json but doesn't order automatically
+// Metadata describes basic details of what makes up a simple metadata record.
+//
+// Insert struct fields in alphabetic order to help achieve deterministic JSON
+// output across peers. Go preserves struct field order when marshaling to JSON,
+// but it does not sort fields automatically.
 type Metadata struct {
-	CreationTimestamp time.Time `json:CreationTimestamp`
-	Hash              string    `json:Hash`
-	HashType          string    `json:HashType`
-	ID                string    `json:ID`
-	SizeInBytes       int       `json:SizeInBytes`
+	CreationTimestamp time.Time `json:"CreationTimestamp"`
+	Hash              string    `json:"Hash"`
+	HashType          string    `json:"HashType"`
+	ID                string    `json:"ID"`
+	SizeInBytes       int       `json:"SizeInBytes"`
 }
 
 func main() {


### PR DESCRIPTION
Correct invalid Go struct tags on Metadata fields so JSON marshaling uses the intended field names. Thank you @marchinm!